### PR TITLE
Fixed No Quote Display Issue

### DIFF
--- a/script.js
+++ b/script.js
@@ -6582,12 +6582,12 @@ getQuote();
 function getQuote() {
   const rndIdx = Math.floor(Math.random() * quotes.length);
   quoteText = quotes[rndIdx].text;
-  quoteAuthor = quotes[rndIdx].author;
+  quoteAuthor = (quotes[rndIdx].author)? quotes[rndIdx].author: "Unknown Author";
   displayQuote(quoteText, quoteAuthor);
 }
 
 function displayQuote(quote, author) {
-  if (quote !== null && author !== null) {
+  if (quote !== null) {
     const textParagraph = document.querySelector(".quote");
     textParagraph.innerHTML = `"${quote}" &mdash; <strong>${author}</strong>`;
   }

--- a/script.js
+++ b/script.js
@@ -6582,7 +6582,7 @@ getQuote();
 function getQuote() {
   const rndIdx = Math.floor(Math.random() * quotes.length);
   quoteText = quotes[rndIdx].text;
-  quoteAuthor = (quotes[rndIdx].author)? quotes[rndIdx].author: "Unknown Author";
+  quoteAuthor = (quotes[rndIdx].author)? quotes[rndIdx].author : "Unknown Author";
   displayQuote(quoteText, quoteAuthor);
 }
 


### PR DESCRIPTION
Upon accessing a quote with a "null" author, webpage will now display the quote with "Unknown Author" instead of nothing.